### PR TITLE
Add ~/.docker to the custom image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,8 @@
 ARG VARIANT=focal
 FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
+
 RUN useradd -ms /bin/bash mock-container
 RUN useradd -ms /bin/bash mock-remote
+
+# Add a pre-existing ~/.docker folder so we can verify the fix for https://github.com/github/codespaces/issues/7185
+RUN mkdir /home/mock-remote/.docker


### PR DESCRIPTION
This sets up the state to verify the fix for https://github.com/github/codespaces/issues/7185 where a pre-existing `~/.docker` folder should not interfere with our ability to properly symlink docker config inside the container.