### PR TITLE
Add postAttachCommand to test gRPC call to run postAttach commands

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,5 +13,6 @@
     "onCreateCommand": "echo $USER > USER.txt",
     "remoteUser": "mock-remote",
     "containerUser": "mock-container",
-    "postCreateCommand": "echo `whoami`> whoami.txt && bash ./run-me.sh"
+    "postCreateCommand": "echo `whoami`> whoami.txt && bash ./run-me.sh",
+    "postAttachCommand": "echo postAttach >> postAttach.txt"
 }


### PR DESCRIPTION
Add postAttachCommand for a gRPC call that needs to be tested as part of the CustomContainerTest.